### PR TITLE
Do not perform a merge instead post comment

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -779,27 +779,6 @@ impl Issue {
         Ok(())
     }
 
-    pub async fn merge(&self, client: &GithubClient) -> anyhow::Result<()> {
-        let merge_url = format!("{}/pulls/{}/merge", self.repository().url(), self.number);
-
-        // change defaults by reading from somewhere, maybe in .toml?
-        #[derive(serde::Serialize)]
-        struct MergeIssue<'a> {
-            commit_title: &'a str,
-            merge_method: &'a str,
-        }
-
-        client
-            ._send_req(client.put(&merge_url).json(&MergeIssue {
-                commit_title: "Merged by the bot!",
-                merge_method: "merge",
-            }))
-            .await
-            .context("failed to merge issue")?;
-
-        Ok(())
-    }
-
     /// Returns the diff in this event, for Open and Synchronize events for now.
     pub async fn diff(&self, client: &GithubClient) -> anyhow::Result<Option<String>> {
         let (before, after) = if let (Some(base), Some(head)) = (&self.base, &self.head) {

--- a/src/interactions.rs
+++ b/src/interactions.rs
@@ -33,15 +33,25 @@ impl<'a> ErrorComment<'a> {
 pub struct PingComment<'a> {
     issue: &'a Issue,
     users: &'a [&'a str],
+    message: String,
 }
 
 impl<'a> PingComment<'a> {
-    pub fn new(issue: &'a Issue, users: &'a [&str]) -> PingComment<'a> {
-        PingComment { issue, users }
+    pub fn new<T>(issue: &'a Issue, users: &'a [&str], message: T) -> PingComment<'a>
+    where
+        T: Into<String>,
+    {
+        PingComment {
+            issue,
+            users,
+            message: message.into(),
+        }
     }
 
     pub async fn post(&self, client: &GithubClient) -> anyhow::Result<()> {
         let mut body = String::new();
+        writeln!(body, "{}", self.message)?;
+        writeln!(body)?;
         for user in self.users {
             write!(body, "@{} ", user)?;
         }


### PR DESCRIPTION
Once the final period has passed and the decision is to merge the issue, do not perform any action but instead post a comment, pinging the involved users again.

Example: 
<img width="962" alt="image" src="https://github.com/jutsuu/triagebot/assets/42446726/bad31eac-306a-4ac6-96ec-c728e584249d">

(note that I added a space after the @ when testing to not actually ping anybody 😄 )
